### PR TITLE
platform: provide macOS alt instruction

### DIFF
--- a/site/content/platforms/envoy/macos.md
+++ b/site/content/platforms/envoy/macos.md
@@ -9,7 +9,9 @@ logo = "/images/macos.svg"
 ## Installation ##
 
 1. **Install [Homebrew](https://brew.sh/).**
-<p><br/></p>
+```sh
+$ /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+```
 
 1. **Add the Tetrate Homebrew GetEnvoy tap.**
 ```sh


### PR DESCRIPTION
For layout consistency sake. (see the sidebar). But one can ignore this, pushed to provide a comparison to what we have on the master branch.

Signed-off-by: Dhi Aurrahman <dio@tetrate.io>