### PR TITLE
Fix link to GitHub repo

### DIFF
--- a/site/config.toml
+++ b/site/config.toml
@@ -34,7 +34,7 @@ pluralizelisttitles = false
 		bio = ""
 		# The icons will be shown if you enter your username
 		twitter = "GetEnvoyProxy"
-		github = "http://github.com/tetratelabs/getenvoy"
+		github = "tetratelabs/getenvoy"
 		gitlab = ""
 		dribbble = ""
 		facebook = ""
@@ -61,13 +61,13 @@ pluralizelisttitles = false
 
     [params.platforms]
         hide  = false
-        
+
     [params.releases]
         hide = true
-    
+
     [params.startnow]
         hide = false
-    
+
     [params.subscribe]
         hide = true
 


### PR DESCRIPTION
Previously, the link to GitHub repo is rendered as:

![image](https://user-images.githubusercontent.com/73152/59576452-0872d080-90ea-11e9-8541-911626b788a5.png)


Signed-off-by: Dhi Aurrahman <dio@tetrate.io>