### PR TITLE
Add install guide for RHEL

### DIFF
--- a/site/content/platforms/envoy/rhel.md
+++ b/site/content/platforms/envoy/rhel.md
@@ -1,0 +1,37 @@
++++
+title = "Install Envoy on Red Hat Enterprise Linux"
+platform = "RHEL"
+tags = []
+categories = []
+logo = "/images/Logo-RedHat-A-Color-RGB.svg"
++++
+
+## Requirements ##
+
+Envoy is supported on Red Hat Enterprise Linux 7 and above.
+
+## Installation ##
+
+1. **Install yum-config-manager utility.**
+```sh
+$ sudo yum install -y yum-utils
+```
+
+1. **Add yum repository config.**
+```sh
+$ sudo yum-config-manager --add-repo https://getenvoy.io/linux/rhel/tetrate-getenvoy.repo
+```
+Nightly packages can be enabled using the `--enable` flag. To disable again, use the `--disable` flag.
+```sh
+$ sudo yum-config-manager --enable tetrate-getenvoy-nightly
+```
+
+1. **Install Envoy binary.**
+```sh
+$ sudo yum install -y getenvoy-envoy
+```
+
+1. **Verify Envoy is installed.**
+```sh
+$ envoy --version
+```

--- a/site/static/linux/rhel/tetrate-getenvoy.repo
+++ b/site/static/linux/rhel/tetrate-getenvoy.repo
@@ -1,0 +1,15 @@
+[tetrate-getenvoy-stable]
+name=Tetrate GetEnvoy - Stable
+baseurl=https://tetrate.bintray.com/getenvoy-rpm/rhel/$releasever/$basearch/stable/
+enabled=1
+gpgkey=https://getenvoy.io/gpg
+gpgcheck=1
+repo_gpgcheck=1
+
+[tetrate-getenvoy-nightly]
+name=Tetrate GetEnvoy - Nightly
+baseurl=https://tetrate.bintray.com/getenvoy-rpm/rhel/$releasever/$basearch/nightly/
+enabled=0
+gpgkey=https://getenvoy.io/gpg
+gpgcheck=1
+repo_gpgcheck=1


### PR DESCRIPTION
Signed-off-by: Taiki Ono <taiki@tetrate.io>

This is almost the same as https://github.com/tetratelabs/getenvoy.io/pull/67. Related PR: https://github.com/tetratelabs/getenvoy-package/pull/3

Checked the repo file `site/static/linux/rhel/tetrate-getenvoy.repo` in RHEL machine on GCP and it works.