### PR TITLE
fix clipboard button

### DIFF
--- a/site/content/install/envoy/docker.md
+++ b/site/content/install/envoy/docker.md
@@ -15,12 +15,12 @@ Any host OS on x86-64 architecture with Docker installed.
 ## Installation ##
 
 1. **Pull the latest docker image.**
-```
+```sh
 $ docker pull getenvoy/envoy:stable
 ```
 
 1. **Verify Envoy image.**
-```
+```sh
 $ docker run getenvoy/envoy:stable --version
 ```
 

--- a/site/themes/getenvoy/static/js/custom.js
+++ b/site/themes/getenvoy/static/js/custom.js
@@ -19,7 +19,6 @@ $(function() {
 
       // parse to get the right linebreaks and such...
       var cmd = getCodeCommand($this);
-      console.log(cmd);
 
       // create the dom input element to do the select/copy then remove...
       var $copyArea = $('<textarea class="to-clipboard hide-me" />')
@@ -46,21 +45,30 @@ $(function() {
 
     function getCodeCommand(block) {
       const inner = block.innerText;
-      const lines = inner.split('\n');
+
+      // check number of $ character
+      let numLine = inner.split('$').length - 1
+      let lines;
       let line = '';
       let cmd = '';
       let arrCmd = []
-      let linesLength = lines.length;
-      for (let i = 0; i < linesLength; i++) {
-        if (lines[i].startsWith('$ ')) {
-          line = lines[i].substring(2);
-          arrCmd.push(line);
+      if (numLine > 1) {
+        lines = inner.split('\n');
+        let linesLength = lines.length;
+        for (let i = 0; i < linesLength; i++) {
+          if (lines[i].startsWith('$ ')) {
+            line = lines[i].substring(2);
+            arrCmd.push(line);
+          }
         }
+        cmd = arrCmd.join (' && ');
+      } else {
+        lines = inner;
+        cmd = lines.substring(2);
       }
-      cmd = arrCmd.join (' && ');
       return cmd;
     }
   }
-
   clipboardMagic();
 });
+

--- a/site/themes/getenvoy/static/js/custom.js
+++ b/site/themes/getenvoy/static/js/custom.js
@@ -45,9 +45,8 @@ $(function() {
 
     function getCodeCommand(block) {
       const inner = block.innerText;
-
       // check number of $ character
-      let numLine = inner.split('$').length - 1
+      let numLine = inner.split('$ ').length - 1
       let lines;
       let line = '';
       let cmd = '';


### PR DESCRIPTION
This PR fixes the clipboard button, so that command with multiple lines separated by `\` will now be copied as-is. Previously, only the first line copied.