### PR TITLE
theme: do not line wrap text inside <code> (that is a result of `backquoted text` in Markdown)

### DIFF
--- a/site/themes/getenvoy/static/css/main.css
+++ b/site/themes/getenvoy/static/css/main.css
@@ -2799,6 +2799,12 @@ article.repo > ul > li {
 		overflow-x: auto;
 	}
 
+	/* Make sure that Markdown text like `GetEnvoy Extension Toolkit` stays on the same line
+	   (for better readability). */
+	p > code, a > code {
+		white-space: nowrap;
+	}
+
 	/* This is a little hacky, if anyone can think of a better way to do this be my guest! */
 	pre+pre code.language-sh-output {
 		margin-top: -2rem;


### PR DESCRIPTION
## Summary

* do not line wrap code blocks like `cargo run`