### PR TITLE
fix repo for RHEL 8+

### DIFF
--- a/site/static/linux/rhel/tetrate-getenvoy.repo
+++ b/site/static/linux/rhel/tetrate-getenvoy.repo
@@ -1,6 +1,6 @@
 [tetrate-getenvoy-stable]
 name=Tetrate GetEnvoy - Stable
-baseurl=https://tetrate.bintray.com/getenvoy-rpm/rhel/$releasever/$basearch/stable/
+baseurl=https://tetrate.bintray.com/getenvoy-rpm/rhel/7Server/$basearch/stable/
 enabled=1
 gpgkey=https://getenvoy.io/gpg
 gpgcheck=1
@@ -8,7 +8,7 @@ repo_gpgcheck=1
 
 [tetrate-getenvoy-nightly]
 name=Tetrate GetEnvoy - Nightly
-baseurl=https://tetrate.bintray.com/getenvoy-rpm/rhel/$releasever/$basearch/nightly/
+baseurl=https://tetrate.bintray.com/getenvoy-rpm/rhel/7Server/$basearch/nightly/
 enabled=0
 gpgkey=https://getenvoy.io/gpg
 gpgcheck=1


### PR DESCRIPTION
RHEL 8+ doesn't have releasever as `8Server`, since we're releasing same binary for RHEL/CentOS, fixing it to `7Server`.

Signed-off-by: Lizan Zhou <lizan@tetrate.io>