### PR TITLE
Migrate to standard:1.17.0 from wasm:1.15

### DIFF
--- a/site/content/reference/getenvoy_extension.md
+++ b/site/content/reference/getenvoy_extension.md
@@ -33,6 +33,7 @@ Explore ready-to-use Envoy extensions or develop a new one.
 * [getenvoy extension clean](/reference/getenvoy_extension_clean)	 - Clean build directory of Envoy extension.
 * [getenvoy extension examples](/reference/getenvoy_extension_examples)	 - Manage example setups.
 * [getenvoy extension init](/reference/getenvoy_extension_init)	 - Scaffold a new Envoy extension.
+* [getenvoy extension push](/reference/getenvoy_extension_push)	 - Push the built WASM extension to the OCI-compliant registry.
 * [getenvoy extension run](/reference/getenvoy_extension_run)	 - Run Envoy extension in the example setup.
 * [getenvoy extension test](/reference/getenvoy_extension_test)	 - Unit test Envoy extension.
 

--- a/site/content/reference/getenvoy_extension_init.md
+++ b/site/content/reference/getenvoy_extension_init.md
@@ -36,7 +36,7 @@ getenvoy extension init [DIR] [flags]
 ```
       --category string   Choose extension category. One of: "envoy.filters.http", "envoy.filters.network", "envoy.access_loggers"
   -h, --help              help for init
-      --language string   Choose programming language. One of: "rust"
+      --language string   Choose programming language. One of: "rust", "tinygo"
       --name string       Choose extension name, e.g. "mycompany.filters.http.custom_metrics"
 ```
 

--- a/site/content/reference/getenvoy_extension_push.md
+++ b/site/content/reference/getenvoy_extension_push.md
@@ -1,0 +1,49 @@
++++
+title = "getenvoy extension push"
+type = "reference"
+parent = "extension"
+command = "push"
++++
+## getenvoy extension push
+
+Push the built WASM extension to the OCI-compliant registry.
+
+### Synopsis
+
+
+Push the built WASM extension to the OCI-compliant registry. This command requires to login the target container registry with docker CLI
+
+```
+getenvoy extension push <image-reference> [flags]
+```
+
+### Examples
+
+```
+
+  # Push built WASM extension to the local docker registry.
+  getenvoy extension push localhost:5000/test/image-name:tag
+```
+
+### Options
+
+```
+      --allow-insecure          allow insecure TLS communication with registry
+      --extension-file string   Use a pre-built *.wasm file
+  -h, --help                    help for push
+      --toolchain string        Name of the toolchain to use, e.g. "default" toolchain that is backed by a Docker build container (default "default")
+      --use-http                Use HTTP for communication with registry
+```
+
+### Options inherited from parent commands
+
+```
+      --home-dir string   GetEnvoy home directory (location of downloaded artifacts, caches, etc) (default "$HOME/.getenvoy")
+      --no-colors         disable colored output
+      --no-prompt         disable automatic switching into interactive mode whenever a parameter is missing or not valid
+```
+
+### SEE ALSO
+
+* [getenvoy extension](/reference/getenvoy_extension)	 - Delve into Envoy extensions.
+

--- a/site/content/reference/getenvoy_extension_run.md
+++ b/site/content/reference/getenvoy_extension_run.md
@@ -25,7 +25,7 @@ getenvoy extension run [flags]
   getenvoy extension run
 
   # Run Envoy extension in the "default" example setup using a particular Envoy release provided by getenvoy.io
-  getenvoy extension run --envoy-version wasm:1.15
+  getenvoy extension run --envoy-version standard:1.17.0
 
   # Run Envoy extension in the "default" example setup using a custom Envoy binary
   getenvoy extension run --envoy-path /path/to/envoy

--- a/site/content/reference/getenvoy_extension_toolkit_reference.md
+++ b/site/content/reference/getenvoy_extension_toolkit_reference.md
@@ -195,7 +195,7 @@ $ getenvoy extension run
 ✅ `getenvoy` will download `Envoy` binary, generate a sample _Envoy_ config and start the _Envoy_ process in the foreground:
 
 ```
-info	Envoy command: [$HOME/.getenvoy/builds/wasm/1.15/darwin/bin/envoy -c /tmp/getenvoy_extension_run732371719/envoy.tmpl.yaml]
+info	Envoy command: [$HOME/.getenvoy/builds/standard/1.17.0/darwin/bin/envoy -c /tmp/getenvoy_extension_run732371719/envoy.tmpl.yaml]
 ...
 [info][main] [external/envoy/source/server/server.cc:339] admin address: 127.0.0.1:9901
 ...
@@ -250,7 +250,7 @@ info	Envoy command: [$HOME/.getenvoy/builds/wasm/1.15/darwin/bin/envoy -c /tmp/g
      # Runtime the extension is being developed against.
      runtime:
        envoy:
-         version: wasm:1.15
+         version: standard:1.17.0
      ```
    ⚠️  Since _WebAssembly_ support in `Envoy` is still under active development, no assumptions can be made about
    [API][`Envoy ABI`] compatibility between various _Envoy_ releases.
@@ -258,7 +258,7 @@ info	Envoy command: [$HOME/.getenvoy/builds/wasm/1.15/darwin/bin/envoy -c /tmp/g
 4. 💻 Next, we need to download `Envoy` binary of that version:
 
      ```shell
-     $ getenvoy fetch wasm:1.15
+     $ getenvoy fetch standard:1.17.0
      ```
    ✅ `getenvoy` will download `Envoy` binary and cache it under `$HOME/.getenvoy`:
 
@@ -266,8 +266,8 @@ info	Envoy command: [$HOME/.getenvoy/builds/wasm/1.15/darwin/bin/envoy -c /tmp/g
      $ tree $HOME/.getenvoy/builds
      
      $HOME/.getenvoy/builds
-     └── wasm
-         └── 1.15
+     └── standard
+         └── 1.17.0
              └── darwin
                  └── bin
                      └── envoy
@@ -280,7 +280,7 @@ info	Envoy command: [$HOME/.getenvoy/builds/wasm/1.15/darwin/bin/envoy -c /tmp/g
    ✅ `getenvoy` will generate the actual `Envoy` config (by resolving placeholders in the configuration template )
    and start the _Envoy_ process in the foreground:
    ```
-   info	Envoy command: [$HOME/.getenvoy/builds/wasm/1.15/darwin/bin/envoy -c /tmp/getenvoy_extension_run732371719/envoy.tmpl. yaml]
+   info	Envoy command: [$HOME/.getenvoy/builds/standard/1.17.0/darwin/bin/envoy -c /tmp/getenvoy_extension_run732371719/envoy.tmpl. yaml]
    ...
    [info][main] [external/envoy/source/server/server.cc:339] admin address: 127.0.0.1:9901
    ...
@@ -425,7 +425,7 @@ language: rust
 # Runtime the extension is being developed against.
 runtime:
   envoy:
-    version: wasm:1.15
+    version: standard:1.17.0
 ```
 
 ### Toolchain
@@ -521,7 +521,7 @@ kind: Example
 # Runtime required by the example.
 runtime:
   envoy:
-    version: wasm:1.15
+    version: standard:1.17.0
 ```
 
 #### envoy.tmpl.yaml

--- a/site/content/reference/getenvoy_extension_toolkit_reference.md
+++ b/site/content/reference/getenvoy_extension_toolkit_reference.md
@@ -280,7 +280,7 @@ info	Envoy command: [$HOME/.getenvoy/builds/standard/1.17.0/darwin/bin/envoy -c 
    ✅ `getenvoy` will generate the actual `Envoy` config (by resolving placeholders in the configuration template )
    and start the _Envoy_ process in the foreground:
    ```
-   info	Envoy command: [$HOME/.getenvoy/builds/standard/1.17.0/darwin/bin/envoy -c /tmp/getenvoy_extension_run732371719/envoy.tmpl. yaml]
+   info	Envoy command: [$HOME/.getenvoy/builds/standard/1.17.0/darwin/bin/envoy -c /tmp/getenvoy_extension_run732371719/envoy.tmpl.yaml]
    ...
    [info][main] [external/envoy/source/server/server.cc:339] admin address: 127.0.0.1:9901
    ...

--- a/site/content/reference/getenvoy_run.md
+++ b/site/content/reference/getenvoy_run.md
@@ -33,6 +33,9 @@ getenvoy run ./envoy -- --config-path ./bootstrap.yaml
 # List available Envoy flags.
 getenvoy run standard:1.11.1 -- --help
 
+# Run with Postgres specific configuration bootstrapped
+getenvoy run postgres:nightly --templateArg endpoints=127.0.0.1:5432,192.168.0.101:5432 --templateArg inport=5555
+
 ```
 
 ### Options
@@ -43,6 +46,7 @@ getenvoy run standard:1.11.1 -- --help
       --controlplaneAddress string      (experimental) location of Envoy's dynamic configuration server <host|ip:port> (requires bootstrap flag)
   -h, --help                            help for run
       --mode string                     (experimental) mode to run Envoy in <loadbalancer> (requires bootstrap flag)
+      --templateArg stringToString      arguments passed to a config template for substitution (default [])
 ```
 
 ### Options inherited from parent commands

--- a/site/content/tutorials/getting-started-http-filter-rust.md
+++ b/site/content/tutorials/getting-started-http-filter-rust.md
@@ -162,13 +162,13 @@ test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
      # Runtime the extension is being developed against.
      runtime:
        envoy:
-         version: wasm:1.15
+         version: standard:1.17.0
      ```
 
 4. 💻 Next, we need to download `Envoy` binary of that version:
 
      ```shell
-     $ getenvoy fetch wasm:1.15
+     $ getenvoy fetch standard:1.17.0
      ```
    ✅ `getenvoy` will download `Envoy` binary and cache it under `$HOME/.getenvoy`:
 
@@ -176,8 +176,8 @@ test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
      $ tree $HOME/.getenvoy/builds
      
      $HOME/.getenvoy/builds
-     └── wasm
-         └── 1.15
+     └── standard
+         └── 1.17.0
              └── darwin
                  └── bin
                      └── envoy
@@ -190,7 +190,7 @@ test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
    ✅ `getenvoy` will generate the actual `Envoy` config (by resolving placeholders in the configuration template )
    and start the _Envoy_ process in the foreground:
    ```
-   info	Envoy command: [$HOME/.getenvoy/builds/wasm/1.15/darwin/bin/envoy -c /tmp/getenvoy_extension_run732371719/envoy.tmpl. yaml]
+   info	Envoy command: [$HOME/.getenvoy/builds/standard/1.17.0/darwin/bin/envoy -c /tmp/getenvoy_extension_run732371719/envoy.tmpl. yaml]
    ...
    [info][main] [external/envoy/source/server/server.cc:339] admin address: 127.0.0.1:9901
    ...
@@ -211,7 +211,7 @@ $ getenvoy extension run
 ✅ `getenvoy` will download `Envoy` binary, generate a sample _Envoy_ config and start the _Envoy_ process in the foreground:
 
 ```
-info	Envoy command: [$HOME/.getenvoy/builds/wasm/1.15/darwin/bin/envoy -c /tmp/getenvoy_extension_run732371719/envoy.tmpl.yaml]
+info	Envoy command: [$HOME/.getenvoy/builds/standard/1.17.0/darwin/bin/envoy -c /tmp/getenvoy_extension_run732371719/envoy.tmpl.yaml]
 ...
 [info][main] [external/envoy/source/server/server.cc:339] admin address: 127.0.0.1:9901
 ...

--- a/site/content/tutorials/getting-started-http-filter-rust.md
+++ b/site/content/tutorials/getting-started-http-filter-rust.md
@@ -190,7 +190,7 @@ test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
    ✅ `getenvoy` will generate the actual `Envoy` config (by resolving placeholders in the configuration template )
    and start the _Envoy_ process in the foreground:
    ```
-   info	Envoy command: [$HOME/.getenvoy/builds/standard/1.17.0/darwin/bin/envoy -c /tmp/getenvoy_extension_run732371719/envoy.tmpl. yaml]
+   info	Envoy command: [$HOME/.getenvoy/builds/standard/1.17.0/darwin/bin/envoy -c /tmp/getenvoy_extension_run732371719/envoy.tmpl.yaml]
    ...
    [info][main] [external/envoy/source/server/server.cc:339] admin address: 127.0.0.1:9901
    ...


### PR DESCRIPTION
This is a doc change corresponding to tetratelabs/getenvoy#114.