### PR TITLE
doc: add related docs of `getenvoy extension push`

### DIFF
--- a/site/content/reference/getenvoy_extension.md
+++ b/site/content/reference/getenvoy_extension.md
@@ -33,6 +33,7 @@ Explore ready-to-use Envoy extensions or develop a new one.
 * [getenvoy extension clean](/reference/getenvoy_extension_clean)	 - Clean build directory of Envoy extension.
 * [getenvoy extension examples](/reference/getenvoy_extension_examples)	 - Manage example setups.
 * [getenvoy extension init](/reference/getenvoy_extension_init)	 - Scaffold a new Envoy extension.
+* [getenvoy extension push](/reference/getenvoy_extension_push)	 - Push the built WASM extension to the OCI-compliant registry.
 * [getenvoy extension run](/reference/getenvoy_extension_run)	 - Run Envoy extension in the example setup.
 * [getenvoy extension test](/reference/getenvoy_extension_test)	 - Unit test Envoy extension.
 

--- a/site/content/reference/getenvoy_extension_init.md
+++ b/site/content/reference/getenvoy_extension_init.md
@@ -36,7 +36,7 @@ getenvoy extension init [DIR] [flags]
 ```
       --category string   Choose extension category. One of: "envoy.filters.http", "envoy.filters.network", "envoy.access_loggers"
   -h, --help              help for init
-      --language string   Choose programming language. One of: "rust"
+      --language string   Choose programming language. One of: "rust", "tinygo"
       --name string       Choose extension name, e.g. "mycompany.filters.http.custom_metrics"
 ```
 

--- a/site/content/reference/getenvoy_extension_push.md
+++ b/site/content/reference/getenvoy_extension_push.md
@@ -1,0 +1,51 @@
++++
+title = "getenvoy extension push"
+type = "reference"
+parent = "extension"
+command = "push"
++++
+## getenvoy extension push
+
+Push the built WASM extension to the OCI-compliant registry.
+
+### Synopsis
+
+
+Push the built WASM extension to the OCI-compliant registry. This command requires to lo
+gin the target container registry with docker CLI
+
+```
+getenvoy extension push <image-reference> [flags]
+```
+
+### Examples
+
+```
+
+  # Push built WASM extension to the local docker registry.
+  getenvoy extension push localhost:5000/test/image-name:tag
+```
+
+### Options
+
+```
+      --allow-insecure          allow insecure TLS communication with registry
+      --extension-file string   Use a pre-built *.wasm file
+  -h, --help                    help for push
+      --toolchain string        Name of the toolchain to use, e.g. "default" toolchain t
+hat is backed by a Docker build container (default "default")
+      --use-http                Use HTTP for communication with registry
+```
+
+### Options inherited from parent commands
+
+```
+      --home-dir string   GetEnvoy home directory (location of downloaded artifacts, caches, etc) (default "$HOME/.getenvoy")
+      --no-colors         disable colored output
+      --no-prompt         disable automatic switching into interactive mode whenever a parameter is missing or not valid
+```
+
+### SEE ALSO
+
+* [getenvoy extension](/reference/getenvoy_extension)	 - Delve into Envoy extensions.
+

--- a/site/content/reference/getenvoy_extension_push.md
+++ b/site/content/reference/getenvoy_extension_push.md
@@ -11,8 +11,7 @@ Push the built WASM extension to the OCI-compliant registry.
 ### Synopsis
 
 
-Push the built WASM extension to the OCI-compliant registry. This command requires to lo
-gin the target container registry with docker CLI
+Push the built WASM extension to the OCI-compliant registry. This command requires to login the target container registry with docker CLI
 
 ```
 getenvoy extension push <image-reference> [flags]
@@ -32,8 +31,7 @@ getenvoy extension push <image-reference> [flags]
       --allow-insecure          allow insecure TLS communication with registry
       --extension-file string   Use a pre-built *.wasm file
   -h, --help                    help for push
-      --toolchain string        Name of the toolchain to use, e.g. "default" toolchain t
-hat is backed by a Docker build container (default "default")
+      --toolchain string        Name of the toolchain to use, e.g. "default" toolchain that is backed by a Docker build container (default "default")
       --use-http                Use HTTP for communication with registry
 ```
 

--- a/site/content/reference/getenvoy_extension_run.md
+++ b/site/content/reference/getenvoy_extension_run.md
@@ -25,7 +25,7 @@ getenvoy extension run [flags]
   getenvoy extension run
 
   # Run Envoy extension in the "default" example setup using a particular Envoy release provided by getenvoy.io
-  getenvoy extension run --envoy-version wasm:1.15
+  getenvoy extension run --envoy-version standard:1.17.0
 
   # Run Envoy extension in the "default" example setup using a custom Envoy binary
   getenvoy extension run --envoy-path /path/to/envoy

--- a/site/content/reference/getenvoy_run.md
+++ b/site/content/reference/getenvoy_run.md
@@ -33,6 +33,9 @@ getenvoy run ./envoy -- --config-path ./bootstrap.yaml
 # List available Envoy flags.
 getenvoy run standard:1.11.1 -- --help
 
+# Run with Postgres specific configuration bootstrapped
+getenvoy run postgres:nightly --templateArg endpoints=127.0.0.1:5432,192.168.0.101:5432 --templateArg inport=5555
+
 ```
 
 ### Options
@@ -43,6 +46,7 @@ getenvoy run standard:1.11.1 -- --help
       --controlplaneAddress string      (experimental) location of Envoy's dynamic configuration server <host|ip:port> (requires bootstrap flag)
   -h, --help                            help for run
       --mode string                     (experimental) mode to run Envoy in <loadbalancer> (requires bootstrap flag)
+      --templateArg stringToString      arguments passed to a config template for substitution (default [])
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
This change is corresponding to  https://github.com/tetratelabs/getenvoy/pull/107.

## summary

- Add the `getenvoy extension push` page to the `getenvoy Reference`