### PR TITLE
Uses simpler syntax for GE 0.3.1

### DIFF
--- a/site/content/install/_index.md
+++ b/site/content/install/_index.md
@@ -13,7 +13,9 @@ Installing and running `getenvoy` on Linux and macOS is as easy as:
 
 ```sh
 $ curl -L https://getenvoy.io/install.sh | bash -s -- -b /usr/local/bin
-$ getenvoy run --version
+$ getenvoy run -c /path/to/envoy.yaml
+# If you don't have a configuration file, you can start the admin port like this
+$ getenvoy run --config-yaml "admin: {access_log_path: '/dev/stdout', address: {socket_address: {address: '127.0.0.1', port_value: 0}}}"
 ```
 
 The CLI is also available via [Homebrew]({{< relref "cli/homebrew">}}).

--- a/site/content/tutorials/front-proxy.md
+++ b/site/content/tutorials/front-proxy.md
@@ -30,8 +30,8 @@ The YAML contains comments explaining the behavior of the relevant sections.
 
 1. **Run Envoy using the static configuration.**
 ```sh
-$ getenvoy use 1.16.4
-$ getenvoy run -c $PWD/basic-front-proxy.yaml
+# basic-front-proxy.yaml currently use old Envoy syntax, so use an older version
+$ ENVOY_VERSION=1.16.4 getenvoy run -c basic-front-proxy.yaml
 ```
 
 1. **Open a new shell and cURL Envoy with `google.com` as the host header.**

--- a/site/content/tutorials/front-proxy.md
+++ b/site/content/tutorials/front-proxy.md
@@ -30,7 +30,7 @@ The YAML contains comments explaining the behavior of the relevant sections.
 
 1. **Run Envoy using the static configuration.**
 ```sh
-# basic-front-proxy.yaml currently use old Envoy syntax, so use an older version
+# basic-front-proxy.yaml currently uses old Envoy syntax, so use an older version
 $ ENVOY_VERSION=1.16.4 getenvoy run -c basic-front-proxy.yaml
 ```
 


### PR DESCRIPTION
This also makes a self-contained example for those lacking a config file,