### PR TITLE
Changes default run command to not use OS-dependent option

### DIFF
--- a/site/content/install/_index.md
+++ b/site/content/install/_index.md
@@ -15,7 +15,7 @@ Installing and running `getenvoy` on Linux and macOS is as easy as:
 $ curl -L https://getenvoy.io/install.sh | bash -s -- -b /usr/local/bin
 $ getenvoy run -c /path/to/envoy.yaml
 # If you don't have a configuration file, you can start the admin port like this
-$ getenvoy run --config-yaml "admin: {access_log_path: '/dev/stdout', address: {socket_address: {address: '127.0.0.1', port_value: 0}}}"
+$ getenvoy run --config-yaml "admin: {address: {socket_address: {address: '127.0.0.1', port_value: 0}}}"
 ```
 
 The CLI is also available via [Homebrew]({{< relref "cli/homebrew">}}).

--- a/site/content/install/_index.md
+++ b/site/content/install/_index.md
@@ -15,7 +15,7 @@ Installing and running `getenvoy` on Linux and macOS is as easy as:
 $ curl -L https://getenvoy.io/install.sh | bash -s -- -b /usr/local/bin
 $ getenvoy run -c /path/to/envoy.yaml
 # If you don't have a configuration file, you can start the admin port like this
-$ getenvoy run --config-yaml "admin: {address: {socket_address: {address: '127.0.0.1', port_value: 0}}}"
+$ getenvoy run --config-yaml "admin: {address: {socket_address: {address: '127.0.0.1', port_value: 9901}}}"
 ```
 
 The CLI is also available via [Homebrew]({{< relref "cli/homebrew">}}).

--- a/site/content/usage/_index.md
+++ b/site/content/usage/_index.md
@@ -15,9 +15,9 @@ your JSON first: https://getenvoy.io/envoy-versions-schema.json
 | Name | Usage |
 | ---- | ----- |
 | help | Shows how to use a [command] |
-| run | Run Envoy with the given [arguments...], collecting process state on termination |
+| run | Run Envoy with the given [arguments...] until interrupted |
 | versions | List Envoy versions |
-| use | Sets the current [version] used by the "run" command, installing as necessary |
+| use | Sets the current [version] used by the "run" command |
 | --version, -v | Print the version of GetEnvoy |
 
 # Environment Variables

--- a/site/themes/getenvoy/layouts/partials/quickstart.html
+++ b/site/themes/getenvoy/layouts/partials/quickstart.html
@@ -3,7 +3,7 @@
     <div id="quickstart-cli">
       <h2>Fetch, run and debug Envoy using the CLI</h2>
       <pre>
-        <code class="language-sh">$ curl -L https://getenvoy.io/install.sh | bash -s -- -b /usr/local/bin <br />$ getenvoy run --config-yaml "admin: {address: {socket_address: {address: '127.0.0.1', port_value: 0}}}"</code>
+        <code class="language-sh">$ curl -L https://getenvoy.io/install.sh | bash -s -- -b /usr/local/bin <br />$ getenvoy run --config-yaml "admin: {address: {socket_address: {address: '127.0.0.1', port_value: 9901}}}"</code>
       </pre>
       <a href="/install">Learn more</a>
     </div>

--- a/site/themes/getenvoy/layouts/partials/quickstart.html
+++ b/site/themes/getenvoy/layouts/partials/quickstart.html
@@ -3,7 +3,7 @@
     <div id="quickstart-cli">
       <h2>Fetch, run and debug Envoy using the CLI</h2>
       <pre>
-        <code class="language-sh">$ curl -L https://getenvoy.io/install.sh | bash -s -- -b /usr/local/bin <br />$ getenvoy run --version</code>
+        <code class="language-sh">$ curl -L https://getenvoy.io/install.sh | bash -s -- -b /usr/local/bin <br />$ getenvoy run --config-yaml "admin: {address: {socket_address: {address: '127.0.0.1', port_value: 0}}}"</code>
       </pre>
       <a href="/install">Learn more</a>
     </div>


### PR DESCRIPTION
`/dev/stdout` wasn't semantically ported to windows so will crash.
Also, `access_log_path` is ignored in envoy 1.19

See https://github.com/tetratelabs/getenvoy/issues/273
See https://github.com/envoyproxy/envoy/pull/15461
