### PR TITLE
Decouples envoy versions from getenvoy repo

### DIFF
--- a/site/static/_redirects
+++ b/site/static/_redirects
@@ -1,7 +1,7 @@
 # See https://docs.netlify.com/routing/redirects/ for syntax
 
 # Redirect latest version of schema and versions json from archive-envoy repo
-/envoy-versions.json https://archive.tetratelabs.io/envoy/envoy-versions.json 200
+/envoy-versions.json https://archive-envoy.netlify.app/envoy-versions.json 200
 /envoy-versions-schema.json https://archive.tetratelabs.io/release-versions-schema.json 200
 
 # Redirect latest version of install.sh from getenvoy repo

--- a/site/static/_redirects
+++ b/site/static/_redirects
@@ -1,8 +1,8 @@
 # See https://docs.netlify.com/routing/redirects/ for syntax
 
-# Redirect latest version of schema and versions json from getenvoy repo
-/envoy-versions.json https://raw.githubusercontent.com/tetratelabs/getenvoy/master/site/envoy-versions.json
-/envoy-versions-schema.json https://raw.githubusercontent.com/tetratelabs/getenvoy/master/site/envoy-versions-schema.json
+# Redirect latest version of schema and versions json from archive-envoy repo
+/envoy-versions.json https://archive.tetratelabs.io/envoy/envoy-versions.json 200
+/envoy-versions-schema.json https://archive.tetratelabs.io/release-versions-schema.json 200
 
 # Redirect latest version of install.sh from getenvoy repo
 /install.sh https://raw.githubusercontent.com/tetratelabs/getenvoy/master/site/install.sh


### PR DESCRIPTION
This ensures existing versions of getenvoy naturally get the new version list

See https://github.com/tetratelabs/getenvoy/pull/282